### PR TITLE
fix(ui): remove misleading 'Active workers' display

### DIFF
--- a/aos-cloud-deployment/index.js
+++ b/aos-cloud-deployment/index.js
@@ -8655,12 +8655,6 @@ items:
             React.createElement(
               "div",
               { style: { padding: "6px 12px 10px", display: "flex", flexDirection: "column", gap: "4px" } },
-              React.createElement(
-                "div",
-                { style: { fontSize: "11px", color: "#6b7280", display: "flex", justifyContent: "space-between" } },
-                React.createElement("span", null, "Active workers"),
-                React.createElement("span", { style: { fontWeight: 600, color: "#374151" } }, String(dockerInstances.filter((d) => d.online && d.type !== "aos-edge-toolchain").length))
-              ),
               workerInfo && React.createElement(
                 "div",
                 { style: { fontSize: "11px", color: "#6b7280", display: "flex", justifyContent: "space-between" } },

--- a/aos-cloud-deployment/src/components/Page.tsx
+++ b/aos-cloud-deployment/src/components/Page.tsx
@@ -1899,10 +1899,6 @@ export default function Page({ data, config }: PluginProps) {
             )
           ),
           React.createElement('div', { style: { padding: '6px 12px 10px', display: 'flex', flexDirection: 'column', gap: '4px' } },
-            React.createElement('div', { style: { fontSize: '11px', color: '#6b7280', display: 'flex', justifyContent: 'space-between' } },
-              React.createElement('span', null, 'Active workers'),
-              React.createElement('span', { style: { fontWeight: 600, color: '#374151' } }, String(dockerInstances.filter(d => d.online && d.type !== 'aos-edge-toolchain').length))
-            ),
             workerInfo && React.createElement('div', { style: { fontSize: '11px', color: '#6b7280', display: 'flex', justifyContent: 'space-between' } },
               React.createElement('span', null, 'Your port'),
               React.createElement('span', { style: { fontWeight: 600, color: '#374151', fontFamily: 'monospace' } }, String(workerInfo.port))


### PR DESCRIPTION
With orchestrator architecture, workers are per-user isolated containers not visible to the UI. The 'Active workers' count always shows 0, which is confusing to users. Remove this display entirely.